### PR TITLE
Gate binary data on the role's `client/state` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ For synchronization, all timing is relative to the server's monotonic clock. The
 
 Client sends state updates to the server. Contains client-level state and role-specific state objects.
 
-Sent once the client is ready to report its operational status (`available`), and whenever any state changes thereafter. A player reports `available: true` only after it has established [clock synchronization](#clock-synchronization). The server MUST NOT send binary data to a client before that client has sent its initial `client/state`. When a role becomes active in `active_roles`, the client MUST send an update that includes that role's object.
+Sent once the client is ready to report its operational status (`available`), and whenever any state changes thereafter. A player reports `available: true` only after it has established [clock synchronization](#clock-synchronization). When a role becomes active in `active_roles`, the client MUST send an update that includes that role's object. The server MUST NOT send a role's binary data until it has received that object. For a role that defines no state object, the client's initial `client/state` opens its binary data instead.
 
 A client whose `active_roles` are non-empty sends the initial `client/state` even when none of its roles defines a state object.
 

--- a/messaging.md
+++ b/messaging.md
@@ -258,7 +258,7 @@ For synchronization, all timing is relative to the server's monotonic clock. The
 
 Client sends state updates to the server. Contains client-level state and role-specific state objects.
 
-Sent once the client is ready to report its operational status (`available`), and whenever any state changes thereafter. A player reports `available: true` only after it has established [clock synchronization](#clock-synchronization). The server MUST NOT send binary data to a client before that client has sent its initial `client/state`. When a role becomes active in `active_roles`, the client MUST send an update that includes that role's object.
+Sent once the client is ready to report its operational status (`available`), and whenever any state changes thereafter. A player reports `available: true` only after it has established [clock synchronization](#clock-synchronization). When a role becomes active in `active_roles`, the client MUST send an update that includes that role's object. The server MUST NOT send a role's binary data until it has received that object. For a role that defines no state object, the client's initial `client/state` opens its binary data instead.
 
 A client whose `active_roles` are non-empty sends the initial `client/state` even when none of its roles defines a state object.
 


### PR DESCRIPTION
Since role objects became optional per `client/state` message, a client can satisfy "has sent its initial `client/state`" with `available` alone and deliver the `player` object later on activation. The binary-data gate in `messaging.md` therefore opened before the server knew `output_delay_ms`, `required_lead_time_ms`, or `min_buffer_ms`.

The gate now requires the role's `client/state` object before that role's binary data. All built-in roles that receive binary data define one, so only application-specific roles without a state object fall back to the initial `client/state`. This matches the `stream/start` rule that waits for the activation update before starting a role's stream.