### PR TITLE
Drop server reconnect give-up guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ Clients may close the connection without sending this message (e.g., crash, netw
 
 - On a connection whose `activities` are empty, or include `'playback'`, servers should assume the disconnect reason is `restart` and attempt to auto-reconnect.
 - Otherwise, servers should treat the drop as a session termination and not auto-reconnect; resumption, if desired, is operator-driven.
-- Servers should also apply backoff on repeated Noise-handshake failures to avoid tight reconnect loops. After repeated consecutive failures, the server SHOULD stop auto-reconnecting until there is reason to expect success (e.g., the client re-announces via mDNS or network conditions change).
+- Servers should also apply backoff on repeated Noise-handshake failures to avoid tight reconnect loops.
 
 ## Pairing
 

--- a/messaging.md
+++ b/messaging.md
@@ -418,4 +418,4 @@ Clients may close the connection without sending this message (e.g., crash, netw
 
 - On a connection whose `activities` are empty, or include `'playback'`, servers should assume the disconnect reason is `restart` and attempt to auto-reconnect.
 - Otherwise, servers should treat the drop as a session termination and not auto-reconnect; resumption, if desired, is operator-driven.
-- Servers should also apply backoff on repeated Noise-handshake failures to avoid tight reconnect loops. After repeated consecutive failures, the server SHOULD stop auto-reconnecting until there is reason to expect success (e.g., the client re-announces via mDNS or network conditions change).
+- Servers should also apply backoff on repeated Noise-handshake failures to avoid tight reconnect loops.


### PR DESCRIPTION
After repeated handshake failures the spec told servers to stop auto-reconnecting until there was reason to expect success, such as a client re-announcing via mDNS. Nothing requires a client to re-announce, so a speaker could stay dark until power-cycled. Per the decision on the issue, this removes that sentence and leaves the retry policy to the server. The backoff guidance for tight reconnect loops stays.

Closes #199