### PR TITLE
Fix activation of roles without support objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Players that can output audio should have the role `player`.
 
 **Note:** Each role version may have its own support object (e.g., `player@v1_support`, `player@v2_support`). Application-specific roles or role versions follow the same pattern (e.g., `_myapp_display@v1_support`, `player@_experimental_support`).
 
-A server MUST NOT activate a role version that was listed in `supported_roles` without its support object.
+A server MUST NOT activate a role version that requires a support object unless that object was included in `client/hello`.
 
 ### Server → Client: `server/activate`
 

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Players that can output audio should have the role `player`.
 
 **Note:** Each role version may have its own support object (e.g., `player@v1_support`, `player@v2_support`). Application-specific roles or role versions follow the same pattern (e.g., `_myapp_display@v1_support`, `player@_experimental_support`).
 
-A server MUST NOT activate a role version that requires a support object unless that object was included in `client/hello`.
+If a role version requires a support object, the server MUST NOT activate that version when the object is missing from `client/hello`.
 
 ### Server → Client: `server/activate`
 

--- a/messaging.md
+++ b/messaging.md
@@ -197,7 +197,7 @@ Players that can output audio should have the role `player`.
 
 **Note:** Each role version may have its own support object (e.g., `player@v1_support`, `player@v2_support`). Application-specific roles or role versions follow the same pattern (e.g., `_myapp_display@v1_support`, `player@_experimental_support`).
 
-A server MUST NOT activate a role version that was listed in `supported_roles` without its support object.
+A server MUST NOT activate a role version that requires a support object unless that object was included in `client/hello`.
 
 ### Server → Client: `server/activate`
 

--- a/messaging.md
+++ b/messaging.md
@@ -197,7 +197,7 @@ Players that can output audio should have the role `player`.
 
 **Note:** Each role version may have its own support object (e.g., `player@v1_support`, `player@v2_support`). Application-specific roles or role versions follow the same pattern (e.g., `_myapp_display@v1_support`, `player@_experimental_support`).
 
-A server MUST NOT activate a role version that requires a support object unless that object was included in `client/hello`.
+If a role version requires a support object, the server MUST NOT activate that version when the object is missing from `client/hello`.
 
 ### Server → Client: `server/activate`
 


### PR DESCRIPTION
The activation rule currently requires a support object even for roles that do not define one. Limit the prohibition to role versions that require a support object, preserving the check when that object is missing from `client/hello`.

Note: This corrects server-side activation validation. Clients do not need to add support objects for roles that do not define one.