### PR TITLE
Clarify required `group/update` fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ Sending `stream/end` in these cases is explicitly prohibited because it signals 
 
 State update of the group this client is part of.
 
-Every message MUST carry the full group state.
+Every message MUST carry all fields listed below.
 
 - `playback_state`: 'playing' | 'stopped' - playback state of the group
 - `group_id`: string - group identifier

--- a/messaging.md
+++ b/messaging.md
@@ -381,7 +381,7 @@ Sending `stream/end` in these cases is explicitly prohibited because it signals 
 
 State update of the group this client is part of.
 
-Every message MUST carry the full group state.
+Every message MUST carry all fields listed below.
 
 - `playback_state`: 'playing' | 'stopped' - playback state of the group
 - `group_id`: string - group identifier


### PR DESCRIPTION
`group/update` is described as carrying the full group state, but it only contains `playback_state`, `group_id`, and `group_name`. Group volume, mute, repeat, and shuffle are sent separately in `server/state.controller`, while track details and progress are sent in `server/state.metadata`, each only when its role is active. The Group definition also mentions membership, but no defined message carries the member list.

This change requires all fields listed for `group/update` without implying that it contains all group state, and does not change the wire format.