### PR TITLE
Clarify image updates when artwork channels are disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1554,7 +1554,7 @@ Servers MUST support 'jpeg' and 'png'.
 
 The server MUST deliver each image at exactly the `width` by `height` declared for the channel. It MUST scale the source image to fit within those dimensions preserving its aspect ratio, MUST pad the remaining area with black, and MUST NOT crop the image.
 
-When a channel's configuration changes while an `artwork` stream is active, the server responds with a [`stream/start`](#server--client-streamstart) carrying the new configuration, followed by immediate artwork updates through binary messages for the channels whose configuration changed.
+When a channel's configuration changes while an `artwork` stream is active, the server responds with a [`stream/start`](#server--client-streamstart) carrying the new configuration, followed by immediate artwork updates through binary messages for the channels whose configuration changed and whose new `source` is not `'none'`.
 
 **None source:** If a channel has `source` set to `none`, the server will not send any artwork data for that channel. This allows clients to disable and enable specific channels on the fly without needing to re-establish the WebSocket connection (useful for dynamic display layouts).
 

--- a/roles/artwork/v1.md
+++ b/roles/artwork/v1.md
@@ -22,7 +22,7 @@ Servers MUST support 'jpeg' and 'png'.
 
 The server MUST deliver each image at exactly the `width` by `height` declared for the channel. It MUST scale the source image to fit within those dimensions preserving its aspect ratio, MUST pad the remaining area with black, and MUST NOT crop the image.
 
-When a channel's configuration changes while an `artwork` stream is active, the server responds with a [`stream/start`](../../messaging.md#server--client-streamstart) carrying the new configuration, followed by immediate artwork updates through binary messages for the channels whose configuration changed.
+When a channel's configuration changes while an `artwork` stream is active, the server responds with a [`stream/start`](../../messaging.md#server--client-streamstart) carrying the new configuration, followed by immediate artwork updates through binary messages for the channels whose configuration changed and whose new `source` is not `'none'`.
 
 **None source:** If a channel has `source` set to `none`, the server will not send any artwork data for that channel. This allows clients to disable and enable specific channels on the fly without needing to re-establish the WebSocket connection (useful for dynamic display layouts).
 


### PR DESCRIPTION
The configuration-change instructions currently call for image updates even when a channel is disabled. Exclude channels whose new `source` is `none`, preserving the existing requirement to clear them before the configuration update.