### PR TITLE
Clarify format updates at natural track transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ Instructs clients to clear buffers without ending the stream. Used for seek oper
 
 Ends the stream for one or more roles. When received, clients should stop output and clear buffers for the specified roles. This message is expected to be sent when playback is over and the queue is empty. Specifically:
 
-- **Track transitions** (a track ends and the next begins naturally): no stream commands should be sent, except an in-place `stream/start` when the stream configuration changes. The stream continues uninterrupted to support gapless playback and server-inserted crossfade.
+- **Track transitions** (a track ends and the next begins naturally): no stream commands should be sent, except `stream/start` to update the existing stream configuration. The stream continues uninterrupted to support gapless playback and server-inserted crossfade.
 - **Seeks** (jumping to a position within the current track): send `stream/clear` instead.
 - **Track jumps** (skipping to a different track): treat identically to a seek, sending `stream/clear` instead of `stream/end`. Conceptually, the entire queue is a single continuous stream.
 

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ Instructs clients to clear buffers without ending the stream. Used for seek oper
 
 Ends the stream for one or more roles. When received, clients should stop output and clear buffers for the specified roles. This message is expected to be sent when playback is over and the queue is empty. Specifically:
 
-- **Track transitions** (a track ends and the next begins naturally): no stream commands should be sent. The stream continues uninterrupted to support gapless playback and server-inserted crossfade.
+- **Track transitions** (a track ends and the next begins naturally): no stream commands should be sent, except an in-place `stream/start` when the stream configuration changes. The stream continues uninterrupted to support gapless playback and server-inserted crossfade.
 - **Seeks** (jumping to a position within the current track): send `stream/clear` instead.
 - **Track jumps** (skipping to a different track): treat identically to a seek, sending `stream/clear` instead of `stream/end`. Conceptually, the entire queue is a single continuous stream.
 

--- a/messaging.md
+++ b/messaging.md
@@ -367,7 +367,7 @@ Instructs clients to clear buffers without ending the stream. Used for seek oper
 
 Ends the stream for one or more roles. When received, clients should stop output and clear buffers for the specified roles. This message is expected to be sent when playback is over and the queue is empty. Specifically:
 
-- **Track transitions** (a track ends and the next begins naturally): no stream commands should be sent, except an in-place `stream/start` when the stream configuration changes. The stream continues uninterrupted to support gapless playback and server-inserted crossfade.
+- **Track transitions** (a track ends and the next begins naturally): no stream commands should be sent, except `stream/start` to update the existing stream configuration. The stream continues uninterrupted to support gapless playback and server-inserted crossfade.
 - **Seeks** (jumping to a position within the current track): send `stream/clear` instead.
 - **Track jumps** (skipping to a different track): treat identically to a seek, sending `stream/clear` instead of `stream/end`. Conceptually, the entire queue is a single continuous stream.
 

--- a/messaging.md
+++ b/messaging.md
@@ -367,7 +367,7 @@ Instructs clients to clear buffers without ending the stream. Used for seek oper
 
 Ends the stream for one or more roles. When received, clients should stop output and clear buffers for the specified roles. This message is expected to be sent when playback is over and the queue is empty. Specifically:
 
-- **Track transitions** (a track ends and the next begins naturally): no stream commands should be sent. The stream continues uninterrupted to support gapless playback and server-inserted crossfade.
+- **Track transitions** (a track ends and the next begins naturally): no stream commands should be sent, except an in-place `stream/start` when the stream configuration changes. The stream continues uninterrupted to support gapless playback and server-inserted crossfade.
 - **Seeks** (jumping to a position within the current track): send `stream/clear` instead.
 - **Track jumps** (skipping to a different track): treat identically to a seek, sending `stream/clear` instead of `stream/end`. Conceptually, the entire queue is a single continuous stream.
 


### PR DESCRIPTION
The core lifecycle prohibits stream commands at natural track transitions, while the player role explicitly allows format changes using `stream/start`. Clarify that in-place configuration updates are allowed without changing the rules against ending or clearing the stream merely because a track ends.

Useful if a server wants to follow the source frequency to minimize resampling.