### PR TITLE
Distinguish clients from players in connection guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Clients announce their presence via mDNS using:
 - Service type: `_sendspin._tcp.local.`
 - Port: The port the Sendspin client is listening on (recommended: `8928`)
 - TXT record: `path` key specifying the WebSocket endpoint, REQUIRED (recommended value: `/sendspin`)
-- TXT record: `name` key specifying the friendly name of the player (optional)
+- TXT record: `name` key specifying the friendly name of the client (optional)
 
 The server discovers available clients through mDNS and connects to each client via WebSocket using the advertised address and path.
 
@@ -457,7 +457,7 @@ First message sent by the server after the Noise handshake completes. Sent as an
 
 Sent by the client once it has received [`server/hello`](#server--client-serverhello). Sent as an encrypted message (binary frame, message type `0`). Contains information about the client's capabilities and roles.
 
-Players that can output audio should have the role `player`.
+Clients that can output audio should have the role `player`.
 
 - `name`: string - friendly name of the client
 - `device_info?`: object - optional information about the device

--- a/connection.md
+++ b/connection.md
@@ -12,7 +12,7 @@ Clients announce their presence via mDNS using:
 - Service type: `_sendspin._tcp.local.`
 - Port: The port the Sendspin client is listening on (recommended: `8928`)
 - TXT record: `path` key specifying the WebSocket endpoint, REQUIRED (recommended value: `/sendspin`)
-- TXT record: `name` key specifying the friendly name of the player (optional)
+- TXT record: `name` key specifying the friendly name of the client (optional)
 
 The server discovers available clients through mDNS and connects to each client via WebSocket using the advertised address and path.
 

--- a/messaging.md
+++ b/messaging.md
@@ -172,7 +172,7 @@ First message sent by the server after the Noise handshake completes. Sent as an
 
 Sent by the client once it has received [`server/hello`](#server--client-serverhello). Sent as an encrypted message (binary frame, message type `0`). Contains information about the client's capabilities and roles.
 
-Players that can output audio should have the role `player`.
+Clients that can output audio should have the role `player`.
 
 - `name`: string - friendly name of the client
 - `device_info?`: object - optional information about the device


### PR DESCRIPTION
Discovery and `client/hello` guidance refer to players where they apply to clients generally. Use client consistently, including devices that do not play audio.