### PR TITLE
Correct the unpaired session record explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ Sent by a paired server to drop its own pairing record from the client. Valid at
 Client behavior:
 
 - Remove the matched pairing record, send [`client/goodbye`](#client--server-clientgoodbye) reason `'unpaired'`, and close the connection.
-- If the session is [unpaired](#definitions), there is no record to remove, so ignore the message and continue unchanged.
+- If the session is [unpaired](#definitions), ignore the message and continue unchanged.
 
 ### Client → Server: `client/goodbye`
 

--- a/messaging.md
+++ b/messaging.md
@@ -394,7 +394,7 @@ Sent by a paired server to drop its own pairing record from the client. Valid at
 Client behavior:
 
 - Remove the matched pairing record, send [`client/goodbye`](#client--server-clientgoodbye) reason `'unpaired'`, and close the connection.
-- If the session is [unpaired](README.md#definitions), there is no record to remove, so ignore the message and continue unchanged.
+- If the session is [unpaired](README.md#definitions), ignore the message and continue unchanged.
 
 ### Client → Server: `client/goodbye`
 


### PR DESCRIPTION
An unpaired session does not necessarily mean the client has no stored pairing record for the server. An already-paired connection can re-handshake to the pairing PSK for re-pairing, making the session unpaired while the previous record still exists. Remove the incorrect explanation while preserving the rule that `server/unpair` is ignored on unpaired sessions.