### PR TITLE
Define source readiness and restart authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1345,6 +1345,10 @@ The `source` object in [`server/command`](#server--client-servercommand) has thi
 
 Both commands are idempotent: a `start` received while the input stream is open MUST NOT restart the stream, and a `stop` received while already stopped is ignored.
 
+The server MUST NOT send `start` unless the source role is active, it has received the source object in the [`client/state`](#client--server-clientstate) update required by that activation, and the latest `client/state` it received reports `available: true`.
+
+A client MUST ignore `start` received while it is unavailable. Becoming available again does not resume streaming without a new `start`.
+
 #### Default streaming behavior
 
 The default after the handshake is `stop`: a source MUST NOT stream until the server sends `command: "start"`. The server is the only party that initiates streaming. An unsolicited `client-stream/start` (received when the server has not issued `start`) is a protocol error: the server MUST NOT treat the input stream as open and should close the connection, consistent with the binary-chunk rejection rule below.
@@ -1353,7 +1357,7 @@ Streaming state is per-connection: a previously sent `start` does not survive re
 
 A source that supports line sensing reports `signal` in [`client/state`](#client--server-clientstate). The server MAY use it as a hint for when to send `command: "start"` or `command: "stop"`, but the decision is server policy.
 
-When the server removes `source` from [`active_roles`](#server--client-serveractivate), the client sends `client-stream/end` and stops sending chunks.
+When the client receives a [`server/activate`](#server--client-serveractivate) removing `source` from `active_roles`, it clears the previous start authorization, stops sending chunks, and sends `client-stream/end` if its input stream is open. After reactivation, the client MUST NOT resume streaming until the server sends a new `start`.
 
 A source with an open input stream that becomes [`available: false`](#external-source-handling) sends `client-stream/end` before it reports `available: false` in `client/state`; the server treats the transition as an implicit `stop`.
 
@@ -1387,7 +1391,7 @@ The client ends the current input stream. After this message, no more source aud
 ### Client → Server: Source Audio Chunks (Binary)
 
 Binary messages SHOULD be rejected by the server if there is no open input stream (i.e., received before a `client-stream/start` or after a `client-stream/end`) or the client is not [`available`](#client--server-clientstate).
-Clients MUST send `client-stream/start` before the first audio chunk. After the server sends `command: "stop"`, chunks may keep arriving until the client processes the command and sends `client-stream/end`; servers MUST tolerate these and MAY discard them.
+Clients MUST send `client-stream/start` before the first audio chunk. After the server sends `command: "stop"` or removes the source role, chunks may keep arriving until the client processes the command or activation and sends `client-stream/end`; servers MUST tolerate these and MAY discard them.
 
 - Byte 0: message type `12` (uint8)
 - Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when the first sample was captured

--- a/roles/source/v1.md
+++ b/roles/source/v1.md
@@ -43,6 +43,10 @@ The `source` object in [`server/command`](../../messaging.md#server--client-serv
 
 Both commands are idempotent: a `start` received while the input stream is open MUST NOT restart the stream, and a `stop` received while already stopped is ignored.
 
+The server MUST NOT send `start` unless the source role is active, it has received the source object in the [`client/state`](../../messaging.md#client--server-clientstate) update required by that activation, and the latest `client/state` it received reports `available: true`.
+
+A client MUST ignore `start` received while it is unavailable. Becoming available again does not resume streaming without a new `start`.
+
 #### Default streaming behavior
 
 The default after the handshake is `stop`: a source MUST NOT stream until the server sends `command: "start"`. The server is the only party that initiates streaming. An unsolicited `client-stream/start` (received when the server has not issued `start`) is a protocol error: the server MUST NOT treat the input stream as open and should close the connection, consistent with the binary-chunk rejection rule below.
@@ -51,7 +55,7 @@ Streaming state is per-connection: a previously sent `start` does not survive re
 
 A source that supports line sensing reports `signal` in [`client/state`](../../messaging.md#client--server-clientstate). The server MAY use it as a hint for when to send `command: "start"` or `command: "stop"`, but the decision is server policy.
 
-When the server removes `source` from [`active_roles`](../../messaging.md#server--client-serveractivate), the client sends `client-stream/end` and stops sending chunks.
+When the client receives a [`server/activate`](../../messaging.md#server--client-serveractivate) removing `source` from `active_roles`, it clears the previous start authorization, stops sending chunks, and sends `client-stream/end` if its input stream is open. After reactivation, the client MUST NOT resume streaming until the server sends a new `start`.
 
 A source with an open input stream that becomes [`available: false`](../../messaging.md#external-source-handling) sends `client-stream/end` before it reports `available: false` in `client/state`; the server treats the transition as an implicit `stop`.
 
@@ -85,7 +89,7 @@ The client ends the current input stream. After this message, no more source aud
 ### Client → Server: Source Audio Chunks (Binary)
 
 Binary messages SHOULD be rejected by the server if there is no open input stream (i.e., received before a `client-stream/start` or after a `client-stream/end`) or the client is not [`available`](../../messaging.md#client--server-clientstate).
-Clients MUST send `client-stream/start` before the first audio chunk. After the server sends `command: "stop"`, chunks may keep arriving until the client processes the command and sends `client-stream/end`; servers MUST tolerate these and MAY discard them.
+Clients MUST send `client-stream/start` before the first audio chunk. After the server sends `command: "stop"` or removes the source role, chunks may keep arriving until the client processes the command or activation and sends `client-stream/end`; servers MUST tolerate these and MAY discard them.
 
 - Byte 0: message type `12` (uint8)
 - Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when the first sample was captured


### PR DESCRIPTION
Source streaming is already gated by availability, but the spec does not require servers to wait for readiness before sending `start` or clearly reset start authorization when the role is removed. Require servers to wait for activation state and the latest received `available: true`, and require clients to ignore starts received while unavailable and wait for a fresh start after role reactivation. Servers tolerate chunks already in flight during removal. This uses existing messages and leaves the separate activation-state correlation gap unresolved.