### PR TITLE
Clarify visualizer frame rates per periodic type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1637,7 +1637,7 @@ The `visualizer` object in [`client/state`](#client--server-clientstate) has thi
 
 - `visualizer`: object
   - `types`: string[] - visualization data types requested by the client: 'beat', 'loudness', 'f_peak', 'peak', 'spectrum'
-  - `rate_max`: integer - maximum periodic visualization frames per second (applies to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo. Clients should set this to their display refresh rate
+  - `rate_max`: integer - maximum periodic visualization frames per second per type (applies independently to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo. Clients should set this to their display refresh rate
   - `spectrum?`: object - spectrum configuration, required if `types` includes 'spectrum'
     - `n_disp_bins`: integer - number of display bins (i.e. bars on a graphical equalizer)
     - `scale`: 'mel' | 'log' | 'lin' - mapping from FFT frequencies to display bins. 'mel' uses the HTK mel formula (`m = 2595 * log10(1 + f/700)`), 'log' uses base-10 logarithm of frequency, 'lin' uses linear frequency spacing
@@ -1654,7 +1654,7 @@ The `visualizer` object in [`stream/start`](#server--client-streamstart) has thi
 
 - `visualizer`: object
   - `types`: string[] - visualization data types the server will stream. MUST be a subset of the types the client requested in its current [`client/state`](#client--server-clientstate-visualizer-object)
-  - `rate_max`: integer - periodic frames per second the server will emit. MUST NOT exceed the client's requested `rate_max`
+  - `rate_max`: integer - periodic frames per second per type the server will emit. MUST NOT exceed the client's requested `rate_max`
   - `tracks_downbeats?`: boolean - required if `types` includes 'beat', absent otherwise. True if the server's beat tracker also identifies bar starts (downbeats). When false, the downbeat flag on `beat` messages is always 0
   - `spectrum?`: object - spectrum configuration, only if `types` includes 'spectrum'. MUST match the client's current requested configuration
     - `n_disp_bins`: integer - number of display bins

--- a/roles/visualizer/v1.md
+++ b/roles/visualizer/v1.md
@@ -20,7 +20,7 @@ The `visualizer` object in [`client/state`](../../messaging.md#client--server-cl
 
 - `visualizer`: object
   - `types`: string[] - visualization data types requested by the client: 'beat', 'loudness', 'f_peak', 'peak', 'spectrum'
-  - `rate_max`: integer - maximum periodic visualization frames per second (applies to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo. Clients should set this to their display refresh rate
+  - `rate_max`: integer - maximum periodic visualization frames per second per type (applies independently to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo. Clients should set this to their display refresh rate
   - `spectrum?`: object - spectrum configuration, required if `types` includes 'spectrum'
     - `n_disp_bins`: integer - number of display bins (i.e. bars on a graphical equalizer)
     - `scale`: 'mel' | 'log' | 'lin' - mapping from FFT frequencies to display bins. 'mel' uses the HTK mel formula (`m = 2595 * log10(1 + f/700)`), 'log' uses base-10 logarithm of frequency, 'lin' uses linear frequency spacing
@@ -37,7 +37,7 @@ The `visualizer` object in [`stream/start`](../../messaging.md#server--client-st
 
 - `visualizer`: object
   - `types`: string[] - visualization data types the server will stream. MUST be a subset of the types the client requested in its current [`client/state`](#client--server-clientstate-visualizer-object)
-  - `rate_max`: integer - periodic frames per second the server will emit. MUST NOT exceed the client's requested `rate_max`
+  - `rate_max`: integer - periodic frames per second per type the server will emit. MUST NOT exceed the client's requested `rate_max`
   - `tracks_downbeats?`: boolean - required if `types` includes 'beat', absent otherwise. True if the server's beat tracker also identifies bar starts (downbeats). When false, the downbeat flag on `beat` messages is always 0
   - `spectrum?`: object - spectrum configuration, only if `types` includes 'spectrum'. MUST match the client's current requested configuration
     - `n_disp_bins`: integer - number of display bins


### PR DESCRIPTION
The visualizer rate limit does not specify whether it applies per type or across all periodic messages. Define `rate_max` per periodic type in both client state and stream configuration, consistent with the existing aiosendspin v1 periodic scheduler. Clients should expect up to the declared rate for each selected periodic type, not that rate in total. Beat and peak remain exempt.