### PR TITLE
Define and enforce visualizer buffer capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1633,9 +1633,9 @@ Timestamps may decrease only after [`stream/clear`](#server--client-streamclear-
 The `visualizer@v1_support` object in [`client/hello`](#client--server-clienthello) has this structure:
 
 - `visualizer@v1_support`: object
-  - `buffer_capacity`: integer - max total size in bytes of buffered visualizer binary messages, counting each reassembled message's type byte, timestamp, and data, excluding transport overhead and decoded storage
+  - `buffer_capacity`: integer - max total size in bytes of buffered visualizer binary messages, counting only each reassembled message's type byte, timestamp, and data
 
-The server MUST NOT send a message if its size plus the total size of previously sent visualizer messages with future timestamps on the server's clock would exceed `buffer_capacity`. Sending a visualizer `stream/clear` or `stream/end` resets this count, but updating its configuration with `stream/start` does not.
+The server MUST NOT send a message if its size plus the total size of previously sent visualizer messages with future timestamps on the server's clock would exceed `buffer_capacity`. Sending a visualizer `stream/clear` or `stream/end` resets this count.
 
 The requested data types, frame-rate cap, and spectrum configuration are dynamic and reported in the [`client/state`](#client--server-clientstate-visualizer-object) visualizer object.
 

--- a/README.md
+++ b/README.md
@@ -1633,7 +1633,9 @@ Timestamps may decrease only after [`stream/clear`](#server--client-streamclear-
 The `visualizer@v1_support` object in [`client/hello`](#client--server-clienthello) has this structure:
 
 - `visualizer@v1_support`: object
-  - `buffer_capacity`: integer - max total size in bytes of buffered visualizer binary messages, counting each message's full wire size (message-type byte + timestamp + data)
+  - `buffer_capacity`: integer - max total size in bytes of buffered visualizer binary messages, counting each reassembled message's type byte, timestamp, and data, excluding transport overhead and decoded storage
+
+The server MUST NOT send a message if its size plus the total size of previously sent visualizer messages with future timestamps on the server's clock would exceed `buffer_capacity`. Sending a visualizer `stream/clear` or `stream/end` resets this count, but updating its configuration with `stream/start` does not.
 
 The requested data types, frame-rate cap, and spectrum configuration are dynamic and reported in the [`client/state`](#client--server-clientstate-visualizer-object) visualizer object.
 

--- a/roles/visualizer/v1.md
+++ b/roles/visualizer/v1.md
@@ -12,9 +12,9 @@ Timestamps may decrease only after [`stream/clear`](#server--client-streamclear-
 The `visualizer@v1_support` object in [`client/hello`](../../messaging.md#client--server-clienthello) has this structure:
 
 - `visualizer@v1_support`: object
-  - `buffer_capacity`: integer - max total size in bytes of buffered visualizer binary messages, counting each reassembled message's type byte, timestamp, and data, excluding transport overhead and decoded storage
+  - `buffer_capacity`: integer - max total size in bytes of buffered visualizer binary messages, counting only each reassembled message's type byte, timestamp, and data
 
-The server MUST NOT send a message if its size plus the total size of previously sent visualizer messages with future timestamps on the server's clock would exceed `buffer_capacity`. Sending a visualizer `stream/clear` or `stream/end` resets this count, but updating its configuration with `stream/start` does not.
+The server MUST NOT send a message if its size plus the total size of previously sent visualizer messages with future timestamps on the server's clock would exceed `buffer_capacity`. Sending a visualizer `stream/clear` or `stream/end` resets this count.
 
 The requested data types, frame-rate cap, and spectrum configuration are dynamic and reported in the [`client/state`](#client--server-clientstate-visualizer-object) visualizer object.
 

--- a/roles/visualizer/v1.md
+++ b/roles/visualizer/v1.md
@@ -12,7 +12,9 @@ Timestamps may decrease only after [`stream/clear`](#server--client-streamclear-
 The `visualizer@v1_support` object in [`client/hello`](../../messaging.md#client--server-clienthello) has this structure:
 
 - `visualizer@v1_support`: object
-  - `buffer_capacity`: integer - max total size in bytes of buffered visualizer binary messages, counting each message's full wire size (message-type byte + timestamp + data)
+  - `buffer_capacity`: integer - max total size in bytes of buffered visualizer binary messages, counting each reassembled message's type byte, timestamp, and data, excluding transport overhead and decoded storage
+
+The server MUST NOT send a message if its size plus the total size of previously sent visualizer messages with future timestamps on the server's clock would exceed `buffer_capacity`. Sending a visualizer `stream/clear` or `stream/end` resets this count, but updating its configuration with `stream/start` does not.
 
 The requested data types, frame-rate cap, and spectrum configuration are dynamic and reported in the [`client/state`](#client--server-clientstate-visualizer-object) visualizer object.
 


### PR DESCRIPTION
Visualizer clients advertise `buffer_capacity`, but the spec does not require servers to enforce it or define when sent messages stop counting. Add a hard limit based on reassembled message bytes and future presentation timestamps on the server clock, with accounting reset by visualizer clear/end.

The player role already describes a hard limit, but its sending rule still uses lowercase "should not" rather than `MUST NOT`. Clarifying player accounting and aligning that wording are tracked separately in #230.