### PR TITLE
Clarify output delay in the player sync target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1249,7 +1249,7 @@ This section defines rules that require all implementations to provide a good ex
 
 ### Sync Accuracy
 
-Sync accuracy is measured at the audio output, against what the time-filter predicts the local time should be (not against the true server clock). Use of the [time-filter](#clock-synchronization) is required to meet these minimum standards. The error is the absolute difference between when a sample actually plays in the client's local clock and the local time the time-filter predicts for that sample's server timestamp.
+Sync accuracy is measured at the audio output, against what the time-filter predicts the local time should be (not against the true server clock). Use of the [time-filter](#clock-synchronization) is required to meet these minimum standards. The error is the absolute difference between when a sample actually plays in the client's local clock and the local time the time-filter predicts for that sample's server timestamp, minus the configured [`output_delay_ms`](#client--server-clientstate-player-object).
 
 Each client is responsible for maintaining its own synchronization with the server's timestamps.
 

--- a/roles/player/v1.md
+++ b/roles/player/v1.md
@@ -121,7 +121,7 @@ This section defines rules that require all implementations to provide a good ex
 
 ### Sync Accuracy
 
-Sync accuracy is measured at the audio output, against what the time-filter predicts the local time should be (not against the true server clock). Use of the [time-filter](../../messaging.md#clock-synchronization) is required to meet these minimum standards. The error is the absolute difference between when a sample actually plays in the client's local clock and the local time the time-filter predicts for that sample's server timestamp.
+Sync accuracy is measured at the audio output, against what the time-filter predicts the local time should be (not against the true server clock). Use of the [time-filter](../../messaging.md#clock-synchronization) is required to meet these minimum standards. The error is the absolute difference between when a sample actually plays in the client's local clock and the local time the time-filter predicts for that sample's server timestamp, minus the configured [`output_delay_ms`](#client--server-clientstate-player-object).
 
 Each client is responsible for maintaining its own synchronization with the server's timestamps.
 


### PR DESCRIPTION
A player connected to an external amplifier with 100 ms of latency must output audio 100 ms before the intended audible timestamp. The existing sync-error definition compares that output with the unadjusted time-filter prediction, so a literal reading counts correct delay compensation as a 100 ms synchronization error. Clarify that the expected output time subtracts the configured `output_delay_ms`. Playback scheduling and the existing internal/external delay distinction are unchanged.