### PR TITLE
Clarify recovery after live buffer requirements increase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1285,7 +1285,7 @@ Each client is responsible for maintaining its own synchronization with the serv
 - For grouped playback, use a common send-ahead equal to the maximum per-player send-ahead across grouped players. Recompute when players join, leave, or update their timing parameters.
 - When the maximum decreases mid-stream (player leaves group, or updates timing), the server may keep the current send-ahead unchanged or reduce it toward the new maximum. The choice depends on implementation priorities (lowest latency vs. glitchless audio).
 - Especially for live streams, servers must schedule timestamps so each player's queued audio duration stays at or above its `min_buffer_ms`. `buffer_capacity` is a hard per-player byte cap and may reduce the effective queued duration below the requested `min_buffer_ms` when the negotiated codec's byte rate would otherwise exceed it.
-- When timing updates or joining players increase the required send-ahead during live playback, the server SHOULD keep the existing timeline until a new stream or `stream/clear`, even if players fall below their requested `min_buffer_ms`.
+- When timing updates or joining players increase the required send-ahead during live playback, players MAY temporarily fall below their requested `min_buffer_ms`. The server SHOULD restore the requested minimum, subject to `buffer_capacity`.
 - For buffered streams, prefer filling each player's queue near `buffer_capacity` to maximize stability.
 - `buffer_capacity` is a hard per-player byte limit; servers should not send data that would cause a player's queued compressed audio to exceed this limit.
 - Servers may rate-limit, debounce, or coalesce a player's timing updates to prevent disruption from frequent or small changes.

--- a/README.md
+++ b/README.md
@@ -1285,6 +1285,7 @@ Each client is responsible for maintaining its own synchronization with the serv
 - For grouped playback, use a common send-ahead equal to the maximum per-player send-ahead across grouped players. Recompute when players join, leave, or update their timing parameters.
 - When the maximum decreases mid-stream (player leaves group, or updates timing), the server may keep the current send-ahead unchanged or reduce it toward the new maximum. The choice depends on implementation priorities (lowest latency vs. glitchless audio).
 - Especially for live streams, servers must schedule timestamps so each player's queued audio duration stays at or above its `min_buffer_ms`. `buffer_capacity` is a hard per-player byte cap and may reduce the effective queued duration below the requested `min_buffer_ms` when the negotiated codec's byte rate would otherwise exceed it.
+- When timing updates or joining players increase the required send-ahead during live playback, the server SHOULD keep the existing timeline until a new stream or `stream/clear`, even if players fall below their requested `min_buffer_ms`.
 - For buffered streams, prefer filling each player's queue near `buffer_capacity` to maximize stability.
 - `buffer_capacity` is a hard per-player byte limit; servers should not send data that would cause a player's queued compressed audio to exceed this limit.
 - Servers may rate-limit, debounce, or coalesce a player's timing updates to prevent disruption from frequent or small changes.

--- a/roles/player/v1.md
+++ b/roles/player/v1.md
@@ -146,6 +146,7 @@ Each client is responsible for maintaining its own synchronization with the serv
 - For grouped playback, use a common send-ahead equal to the maximum per-player send-ahead across grouped players. Recompute when players join, leave, or update their timing parameters.
 - When the maximum decreases mid-stream (player leaves group, or updates timing), the server may keep the current send-ahead unchanged or reduce it toward the new maximum. The choice depends on implementation priorities (lowest latency vs. glitchless audio).
 - Especially for live streams, servers must schedule timestamps so each player's queued audio duration stays at or above its `min_buffer_ms`. `buffer_capacity` is a hard per-player byte cap and may reduce the effective queued duration below the requested `min_buffer_ms` when the negotiated codec's byte rate would otherwise exceed it.
+- When timing updates or joining players increase the required send-ahead during live playback, the server SHOULD keep the existing timeline until a new stream or `stream/clear`, even if players fall below their requested `min_buffer_ms`.
 - For buffered streams, prefer filling each player's queue near `buffer_capacity` to maximize stability.
 - `buffer_capacity` is a hard per-player byte limit; servers should not send data that would cause a player's queued compressed audio to exceed this limit.
 - Servers may rate-limit, debounce, or coalesce a player's timing updates to prevent disruption from frequent or small changes.

--- a/roles/player/v1.md
+++ b/roles/player/v1.md
@@ -146,7 +146,7 @@ Each client is responsible for maintaining its own synchronization with the serv
 - For grouped playback, use a common send-ahead equal to the maximum per-player send-ahead across grouped players. Recompute when players join, leave, or update their timing parameters.
 - When the maximum decreases mid-stream (player leaves group, or updates timing), the server may keep the current send-ahead unchanged or reduce it toward the new maximum. The choice depends on implementation priorities (lowest latency vs. glitchless audio).
 - Especially for live streams, servers must schedule timestamps so each player's queued audio duration stays at or above its `min_buffer_ms`. `buffer_capacity` is a hard per-player byte cap and may reduce the effective queued duration below the requested `min_buffer_ms` when the negotiated codec's byte rate would otherwise exceed it.
-- When timing updates or joining players increase the required send-ahead during live playback, the server SHOULD keep the existing timeline until a new stream or `stream/clear`, even if players fall below their requested `min_buffer_ms`.
+- When timing updates or joining players increase the required send-ahead during live playback, players MAY temporarily fall below their requested `min_buffer_ms`. The server SHOULD restore the requested minimum, subject to `buffer_capacity`.
 - For buffered streams, prefer filling each player's queue near `buffer_capacity` to maximize stability.
 - `buffer_capacity` is a hard per-player byte limit; servers should not send data that would cause a player's queued compressed audio to exceed this limit.
 - Servers may rate-limit, debounce, or coalesce a player's timing updates to prevent disruption from frequent or small changes.


### PR DESCRIPTION
A live group may be playing with 100 ms of lead when a timing update or joining player raises the requirement to 300 ms, but the additional live audio is not yet available. The spec requires recomputing send-ahead without defining the transition to a larger buffer. Allow players to temporarily fall below their requested `min_buffer_ms` and recommend that the server restore the requested minimum, subject to `buffer_capacity`, without prescribing a recovery mechanism or deadline.