### PR TITLE
Clarify that unpairing removes both pairing records

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,8 @@ Every message MUST carry all fields listed below.
 
 Sent by a paired server to drop its own pairing record from the client. Valid at any time regardless of the current `activities`. No payload fields.
 
+The server also removes its corresponding pairing record.
+
 Client behavior:
 
 - Remove the matched pairing record, send [`client/goodbye`](#client--server-clientgoodbye) reason `'unpaired'`, and close the connection.

--- a/messaging.md
+++ b/messaging.md
@@ -401,6 +401,8 @@ Every message MUST carry all fields listed below.
 
 Sent by a paired server to drop its own pairing record from the client. Valid at any time regardless of the current `activities`. No payload fields.
 
+The server also removes its corresponding pairing record.
+
 Client behavior:
 
 - Remove the matched pairing record, send [`client/goodbye`](#client--server-clientgoodbye) reason `'unpaired'`, and close the connection.


### PR DESCRIPTION
`server/unpair` explicitly removes the client record but leaves the server-side outcome unstated. A server retaining and later reusing the old credential would enter the credential-mismatch flow instead of treating the relationship as deliberately unpaired. Clarify that the server also removes its corresponding record, without prescribing deletion timing or storage operations.