### PR TITLE
Include format selection in the dynamic pairing diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,7 +831,7 @@ sequenceDiagram
     Server->>Client: server/hello (name)
     Client->>Server: client/hello (supported_pair_methods)
     Note over Server: Operator picks dynamic pairing code
-    Server->>Client: server/activate (activities=['pairing'], active_roles=[], pairing={method: dynamic_pairing_code})
+    Server->>Client: server/activate (activities=['pairing'], active_roles=[], pairing={method: dynamic_pairing_code, format: digits|qr_code})
     opt attempt held back
         Client->>Server: client/pair-pending
         Note over Client: Cooldown elapses or operator acts

--- a/pairing.md
+++ b/pairing.md
@@ -109,7 +109,7 @@ sequenceDiagram
     Server->>Client: server/hello (name)
     Client->>Server: client/hello (supported_pair_methods)
     Note over Server: Operator picks dynamic pairing code
-    Server->>Client: server/activate (activities=['pairing'], active_roles=[], pairing={method: dynamic_pairing_code})
+    Server->>Client: server/activate (activities=['pairing'], active_roles=[], pairing={method: dynamic_pairing_code, format: digits|qr_code})
     opt attempt held back
         Client->>Server: client/pair-pending
         Note over Client: Cooldown elapses or operator acts


### PR DESCRIPTION
Dynamic pairing requires a `pairing.format`, but the sequence diagram omits it from `server/activate`. Add `format: digits|qr_code` to show the required selection while retaining both alternatives in the diagram. This corrects the example without changing protocol behavior.