### PR TITLE
Describe the server-side pairing record

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,8 @@ Clients with a usable out-channel (display, speaker, etc.) should offer `dynamic
 
 Each successful pairing produces a pairing record: the new [long-term PSK](#definitions) persisted together with the server's `server_id`. The client MUST persist the new record, replacing any record it already holds for the server.
 
+The server persists the long-term PSK together with the client's `client_id`.
+
 A client MUST be able to store at least 5 pairing records; more is allowed. When a pairing completes at capacity, the client MUST evict an existing record so that the new record persists - a pairing never fails for lack of record storage. Which record is evicted is implementation-defined (for example, the least recently used), except that the client MUST NOT evict a record backing a currently-open connection, provisional or admitted; the client MUST cap its concurrently open paired connections below its record capacity (see [Multiple servers](#multiple-servers-server-initiated)) so an evictable record always exists.
 
 Eviction needs no wire signal. An evicted server's next handshake references a `psk_id` the client no longer holds and lands in the [Sentinel Fallback](#sentinel-fallback): the server receives an authenticated credential-mismatch signal and can offer its operator re-pairing.

--- a/pairing.md
+++ b/pairing.md
@@ -22,6 +22,8 @@ Clients with a usable out-channel (display, speaker, etc.) should offer `dynamic
 
 Each successful pairing produces a pairing record: the new [long-term PSK](README.md#definitions) persisted together with the server's `server_id`. The client MUST persist the new record, replacing any record it already holds for the server.
 
+The server persists the long-term PSK together with the client's `client_id`.
+
 A client MUST be able to store at least 5 pairing records; more is allowed. When a pairing completes at capacity, the client MUST evict an existing record so that the new record persists - a pairing never fails for lack of record storage. Which record is evicted is implementation-defined (for example, the least recently used), except that the client MUST NOT evict a record backing a currently-open connection, provisional or admitted; the client MUST cap its concurrently open paired connections below its record capacity (see [Multiple servers](connection.md#multiple-servers-server-initiated)) so an evictable record always exists.
 
 Eviction needs no wire signal. An evicted server's next handshake references a `psk_id` the client no longer holds and lands in the [Sentinel Fallback](connection.md#sentinel-fallback): the server receives an authenticated credential-mismatch signal and can offer its operator re-pairing.


### PR DESCRIPTION
Pairing requires both peers to persist a record, but the Pairing Records section only describes the client's association with `server_id`. Add the corresponding server-side association between the long-term PSK and `client_id`, without prescribing storage structure or changing the wire protocol.