### PR TITLE
Align command wording with active roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ When a client returns to `available: true`, the server MUST NOT auto-rejoin it t
 
 ### Client → Server: `client/command`
 
-Client sends commands to the server. Contains command objects based on the client's supported roles.
+Client sends commands to the server. Contains command objects based on the client's active roles.
 
 - `controller?`: object - only if client has `controller` role ([see controller command object details](#client--server-clientcommand-controller-object))
 

--- a/messaging.md
+++ b/messaging.md
@@ -305,7 +305,7 @@ When a client returns to `available: true`, the server MUST NOT auto-rejoin it t
 
 ### Client → Server: `client/command`
 
-Client sends commands to the server. Contains command objects based on the client's supported roles.
+Client sends commands to the server. Contains command objects based on the client's active roles.
 
 - `controller?`: object - only if client has `controller` role ([see controller command object details](roles/controller/v1.md#client--server-clientcommand-controller-object))
 


### PR DESCRIPTION
The `client/command` description refers to supported roles, although the activation rules already restrict commands to active roles. Replace "supported" with "active" so advertising a role is not confused with permission to send its commands.