### PR TITLE
Remove the claim that clients only consume data

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The TXT `name` SHOULD match the `name` the server sends in [`server/hello`](#ser
 
 Unlike server-initiated connections, servers cannot reclaim clients by reconnecting. How clients handle multiple discovered servers, server selection, and switching is implementation-defined.
 
-**Note:** After this point, Sendspin works independently of how the connection was established. The Sendspin client is always the consumer of data like audio or metadata, regardless of who initiated the connection.
+**Note:** After this point, Sendspin works independently of how the connection was established.
 
 ## Encryption
 

--- a/connection.md
+++ b/connection.md
@@ -59,7 +59,7 @@ The TXT `name` SHOULD match the `name` the server sends in [`server/hello`](mess
 
 Unlike server-initiated connections, servers cannot reclaim clients by reconnecting. How clients handle multiple discovered servers, server selection, and switching is implementation-defined.
 
-**Note:** After this point, Sendspin works independently of how the connection was established. The Sendspin client is always the consumer of data like audio or metadata, regardless of who initiated the connection.
+**Note:** After this point, Sendspin works independently of how the connection was established.
 
 ## Encryption
 


### PR DESCRIPTION
The connection note says a Sendspin client is always a consumer of audio or metadata, which does not account for source clients sending audio to the server. Remove that sentence and retain the preceding statement that Sendspin works independently of how the connection was established.