### PR TITLE
Remove the misleading server-initiated mDNS caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Their binary message IDs come from the unmanaged 192-255 range: an application-s
 
 ## Establishing a Connection
 
-Sendspin has two standard ways to establish connections: Server and Client initiated. Server Initiated connections are recommended as they provide standardized multi-server behavior, but require mDNS which may not be available in all environments.
+Sendspin has two standard ways to establish connections: Server and Client initiated. Server Initiated connections are recommended as they provide standardized multi-server behavior.
 
 Servers must support both methods described below. Clients MUST use exactly one of the two methods at a time, advertising or discovering accordingly.
 

--- a/connection.md
+++ b/connection.md
@@ -1,6 +1,6 @@
 ## Establishing a Connection
 
-Sendspin has two standard ways to establish connections: Server and Client initiated. Server Initiated connections are recommended as they provide standardized multi-server behavior, but require mDNS which may not be available in all environments.
+Sendspin has two standard ways to establish connections: Server and Client initiated. Server Initiated connections are recommended as they provide standardized multi-server behavior.
 
 Servers must support both methods described below. Clients MUST use exactly one of the two methods at a time, advertising or discovering accordingly.
 


### PR DESCRIPTION
The introduction singles out mDNS as a drawback of server-initiated connections even though both standard discovery methods use it. Remove that caveat while retaining the standardized multi-server-behavior recommendation and the discovery requirements for both methods.