### PR TITLE
Remove the redundant discovery-scoped encryption statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Unlike server-initiated connections, servers cannot reclaim clients by reconnect
 
 ## Encryption
 
-All Sendspin connections use end-to-end encryption based on the [Noise Protocol Framework](https://noiseprotocol.org/noise.html). Encryption is mandatory for all connections established through the standard discovery mechanisms described in [Establishing a Connection](#establishing-a-connection).
+All Sendspin connections use end-to-end encryption based on the [Noise Protocol Framework](https://noiseprotocol.org/noise.html).
 
 ### Pattern
 

--- a/connection.md
+++ b/connection.md
@@ -63,7 +63,7 @@ Unlike server-initiated connections, servers cannot reclaim clients by reconnect
 
 ## Encryption
 
-All Sendspin connections use end-to-end encryption based on the [Noise Protocol Framework](https://noiseprotocol.org/noise.html). Encryption is mandatory for all connections established through the standard discovery mechanisms described in [Establishing a Connection](#establishing-a-connection).
+All Sendspin connections use end-to-end encryption based on the [Noise Protocol Framework](https://noiseprotocol.org/noise.html).
 
 ### Pattern
 


### PR DESCRIPTION
The encryption section requires encryption for all Sendspin connections, then repeats that requirement only for connections established through standard discovery. Delete the narrower sentence so it does not suggest an exception for other connection methods.