### PR TITLE
Clarify client-role self-containment guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ to intra-page anchors at build time.
 
 The source files follow these rules. Check a change against them before proposing it; reviewers point to them instead of re-explaining.
 
-- **Each role file is self-contained.** A reader who implements one role must not need to read another role file. Text that applies to more than one role therefore appears more than once - the PCM encoding convention and codec framing rules, for example, appear in both `roles/player/v1.md` and `roles/source/v1.md`. Do not combine such text into a shared section.
+- **Each role file is self-contained.** A reader who implements one client role must not need to read another role file. Text that applies to more than one role therefore appears more than once - the PCM encoding convention and codec framing rules, for example, appear in both `roles/player/v1.md` and `roles/source/v1.md`. Do not combine such text into a shared section.
 - **A client describes itself across `client/hello` and `client/state`.** A field expected to change during a connection belongs in `client/state`; a field expected to stay constant for the connection, such as device identity or a fixed hardware limit, belongs in `client/hello`. `client/hello` is sent once per connection, so a field placed there can only be updated by reconnecting.
 - **Edit the source files, never `README.md`.** `README.md` is generated; the pre-commit hook regenerates it and blocks direct edits.
 - **Every heading needs a unique anchor.** The build fails on two headings that produce the same anchor, and on a link to an anchor with no matching heading.


### PR DESCRIPTION
The self-containment rule currently says implementing one role must not require reading another role's specification, but the controller section references player state and capabilities to explain how servers calculate group volume and mute. Those cross-role rules are needed by the server, not a controller-only client, which receives the calculated state.

Scope the rule to client-role implementations so these existing controller references are consistent with the editorial guidance without duplicating the player specification.