### PR TITLE
Require initial and changed group-state publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,8 @@ Sending `stream/end` in these cases is explicitly prohibited because it signals 
 
 State update of the group this client is part of.
 
+The server MUST promptly send this message after the first `server/activate` on a connection and whenever any field listed below changes.
+
 Every message MUST carry all fields listed below.
 
 - `playback_state`: 'playing' | 'stopped' - playback state of the group

--- a/messaging.md
+++ b/messaging.md
@@ -390,6 +390,8 @@ Sending `stream/end` in these cases is explicitly prohibited because it signals 
 
 State update of the group this client is part of.
 
+The server MUST promptly send this message after the first `server/activate` on a connection and whenever any field listed below changes.
+
 Every message MUST carry all fields listed below.
 
 - `playback_state`: 'playing' | 'stopped' - playback state of the group


### PR DESCRIPTION
The group-update message defines its fields but does not generally require initial publication or updates when those values change. Require an initial message after the first activation and prompt updates when group identity, group name, or playback state changes, covering switches and renames without adding fields.