### PR TITLE
Clarify artwork stream lifecycle and data handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1591,7 +1591,11 @@ Each channel's configuration MUST match the channel's current [`client/state`](#
 
 ### Server → Client: Artwork (Binary)
 
-Binary messages SHOULD be rejected if there is no active stream or the client is not [`available`](#client--server-clientstate). Rejection does not affect transfer state: a rejected announce still starts its transfer and rejected parts still advance it. A client that rejects an image discards its data but keeps the transfer's channel, `total_size`, and count of received bytes, so it can still tell which messages belong to the transfer and when it completes.
+Servers MUST NOT send artwork messages outside an active artwork stream.
+
+During an active stream, unavailable clients SHOULD discard otherwise valid image data and MUST NOT close solely for its arrival.
+
+During an active stream, clients discarding image data MUST still process announces and cancels and count each part's `data` bytes toward `total_size`.
 
 An image is transferred as an announce followed by the parts of the encoded image, all on its channel. The announce carries the image's total size and no image data.
 
@@ -1615,13 +1619,15 @@ At most one image transfer is in flight at a time across all of the role's chann
 
 A server SHOULD pace a transfer's parts instead of sending them back to back. Artwork is not time critical, so spreading the parts out keeps a large image from delaying the other roles the connection carries, such as `player@v1` audio chunks.
 
-The timestamp indicates when this artwork should be displayed. Per channel, clients keep the **current image**, which is always what the channel shows, plus at most one **pending image**: the most recently announced image, from its announce until it becomes current. An announce discards that channel's pending image. The pending image becomes current once its transfer is complete and its timestamp, translated to the local clock via the [time filter](#clock-synchronization) (current best estimate, no waiting for convergence), has been reached; artwork is never dropped for lateness. Clients MAY ease into a complete pending image around its timestamp (e.g. a cross-fade) or show it early (e.g. a coming-up display). On [`stream/end`](#server--client-streamend), clearing buffers includes discarding pending images. A [`stream/start`](#server--client-streamstart) that changes a channel's configuration likewise discards that channel's pending image, and the server re-sends the image if it still applies.
+The timestamp indicates when this artwork should be displayed. Per channel, clients keep the **current image**, which is always what the channel shows, plus at most one **pending image**: the most recently announced image, from its announce until it becomes current. An announce discards that channel's pending image. The pending image becomes current once its transfer is complete and its timestamp, translated to the local clock via the [time filter](#clock-synchronization) (current best estimate, no waiting for convergence), has been reached; artwork is never dropped for lateness. Clients MAY ease into a complete pending image around its timestamp (e.g. a cross-fade) or show it early (e.g. a coming-up display). On [`stream/end`](#server--client-streamend) for the artwork role, clients MUST clear the current image and discard any pending image, so the channel no longer displays artwork. A [`stream/start`](#server--client-streamstart) that changes a channel's configuration likewise discards that channel's pending image, and the server re-sends the image if it still applies.
 
 **Clearing artwork:** To clear the currently displayed artwork on a specific channel, the server sends an empty image for that channel: an announce with `total_size` `0`. An empty image follows the same rules as any other image: a future timestamp schedules the clear. Before a [`stream/start`](#server--client-streamstart) sets a channel's `source` to `'none'`, the server MUST clear that channel this way, using a past or present timestamp.
 
 **Cancel message:** A message consisting of only the `type` and `flags` bytes, with bit 0 set. It discards the channel's pending image, taking effect immediately; the current image is unaffected.
 
-**Malformed sequences** are protocol errors; the client MUST close the connection. They are: a message shorter than 2 bytes or exceeding the size cap above, an announce whose length is not 14 bytes, an announce received while a transfer is in flight, a cancel message longer than 2 bytes, a part received with no transfer in flight or on a channel other than the in-flight transfer's, a part whose `data` would extend past `total_size`, a nonzero reserved flag bit, and a message with bit 0 and bit 1 both set.
+**Malformed messages** are protocol errors: the client MUST close the connection. They are: a message shorter than 2 bytes or exceeding the size cap above, an announce whose length is not 14 bytes, a cancel message longer than 2 bytes, a nonzero reserved flag bit, and a message with bit 0 and bit 1 both set.
+
+**Malformed sequences within an active artwork stream** also require the client to close the connection: an announce received while a transfer is in flight, a part received with no transfer in flight or on a channel other than the in-flight transfer's, and a part whose `data` would extend past `total_size`.
 
 #### Server rules for scheduled artwork
 

--- a/roles/artwork/v1.md
+++ b/roles/artwork/v1.md
@@ -45,7 +45,11 @@ Each channel's configuration MUST match the channel's current [`client/state`](#
 
 ### Server → Client: Artwork (Binary)
 
-Binary messages SHOULD be rejected if there is no active stream or the client is not [`available`](../../messaging.md#client--server-clientstate). Rejection does not affect transfer state: a rejected announce still starts its transfer and rejected parts still advance it. A client that rejects an image discards its data but keeps the transfer's channel, `total_size`, and count of received bytes, so it can still tell which messages belong to the transfer and when it completes.
+Servers MUST NOT send artwork messages outside an active artwork stream.
+
+During an active stream, unavailable clients SHOULD discard otherwise valid image data and MUST NOT close solely for its arrival.
+
+During an active stream, clients discarding image data MUST still process announces and cancels and count each part's `data` bytes toward `total_size`.
 
 An image is transferred as an announce followed by the parts of the encoded image, all on its channel. The announce carries the image's total size and no image data.
 
@@ -69,13 +73,15 @@ At most one image transfer is in flight at a time across all of the role's chann
 
 A server SHOULD pace a transfer's parts instead of sending them back to back. Artwork is not time critical, so spreading the parts out keeps a large image from delaying the other roles the connection carries, such as `player@v1` audio chunks.
 
-The timestamp indicates when this artwork should be displayed. Per channel, clients keep the **current image**, which is always what the channel shows, plus at most one **pending image**: the most recently announced image, from its announce until it becomes current. An announce discards that channel's pending image. The pending image becomes current once its transfer is complete and its timestamp, translated to the local clock via the [time filter](../../messaging.md#clock-synchronization) (current best estimate, no waiting for convergence), has been reached; artwork is never dropped for lateness. Clients MAY ease into a complete pending image around its timestamp (e.g. a cross-fade) or show it early (e.g. a coming-up display). On [`stream/end`](../../messaging.md#server--client-streamend), clearing buffers includes discarding pending images. A [`stream/start`](../../messaging.md#server--client-streamstart) that changes a channel's configuration likewise discards that channel's pending image, and the server re-sends the image if it still applies.
+The timestamp indicates when this artwork should be displayed. Per channel, clients keep the **current image**, which is always what the channel shows, plus at most one **pending image**: the most recently announced image, from its announce until it becomes current. An announce discards that channel's pending image. The pending image becomes current once its transfer is complete and its timestamp, translated to the local clock via the [time filter](../../messaging.md#clock-synchronization) (current best estimate, no waiting for convergence), has been reached; artwork is never dropped for lateness. Clients MAY ease into a complete pending image around its timestamp (e.g. a cross-fade) or show it early (e.g. a coming-up display). On [`stream/end`](../../messaging.md#server--client-streamend) for the artwork role, clients MUST clear the current image and discard any pending image, so the channel no longer displays artwork. A [`stream/start`](../../messaging.md#server--client-streamstart) that changes a channel's configuration likewise discards that channel's pending image, and the server re-sends the image if it still applies.
 
 **Clearing artwork:** To clear the currently displayed artwork on a specific channel, the server sends an empty image for that channel: an announce with `total_size` `0`. An empty image follows the same rules as any other image: a future timestamp schedules the clear. Before a [`stream/start`](../../messaging.md#server--client-streamstart) sets a channel's `source` to `'none'`, the server MUST clear that channel this way, using a past or present timestamp.
 
 **Cancel message:** A message consisting of only the `type` and `flags` bytes, with bit 0 set. It discards the channel's pending image, taking effect immediately; the current image is unaffected.
 
-**Malformed sequences** are protocol errors; the client MUST close the connection. They are: a message shorter than 2 bytes or exceeding the size cap above, an announce whose length is not 14 bytes, an announce received while a transfer is in flight, a cancel message longer than 2 bytes, a part received with no transfer in flight or on a channel other than the in-flight transfer's, a part whose `data` would extend past `total_size`, a nonzero reserved flag bit, and a message with bit 0 and bit 1 both set.
+**Malformed messages** are protocol errors: the client MUST close the connection. They are: a message shorter than 2 bytes or exceeding the size cap above, an announce whose length is not 14 bytes, a cancel message longer than 2 bytes, a nonzero reserved flag bit, and a message with bit 0 and bit 1 both set.
+
+**Malformed sequences within an active artwork stream** also require the client to close the connection: an announce received while a transfer is in flight, a part received with no transfer in flight or on a channel other than the in-flight transfer's, and a part whose `data` would extend past `total_size`.
 
 #### Server rules for scheduled artwork
 


### PR DESCRIPTION
Clarify artwork receiver behavior and stream-end effects. Changes beyond keyword normalization:

- Require artwork `stream/end` to clear the current image as well as discard any pending image, so the channel stops displaying artwork.
- Replace ambiguous binary-message rejection guidance with a sender prohibition outside an active artwork stream. During an active stream, unavailable clients SHOULD discard otherwise valid image data and MUST NOT close solely because it arrived - availability updates and image data can cross in flight.
- Require clients discarding artwork during an active stream to process announces and cancels and count each part's `data` bytes toward `total_size` - discarding data must not lose track of transfer boundaries.
- Separate malformed artwork messages from malformed transfer sequences. Message-format errors still require closure, while the transfer-sequence closure rules apply within an active artwork stream - this avoids mandating closure solely for valid data arriving outside a stream.

Addresses part of #100.