### PR TITLE
Clarify controller commands and group-volume rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1416,16 +1416,16 @@ Source timestamps are derived from the [time filter](#clock-synchronization)'s m
 ## Controller messages
 This section describes messages specific to clients with the `controller` role, which enables the client to control the group this client is part of, and switch between groups.
 
-Every client which lists the `controller` role in the `supported_roles` of the `client/hello` message needs to implement all messages in this section.
+Every client which lists the `controller` role in the `supported_roles` of the `client/hello` message MUST implement all messages in this section.
 
 ### Client → Server: `client/command` controller object
 
 The `controller` object in [`client/command`](#client--server-clientcommand) has this structure:
 
-Control the group that's playing and switch groups. Only valid from clients with the `controller` role.
+Control the group that's playing and switch groups. Only valid from clients whose `controller` role is active.
 
 - `controller`: object
-  - `command`: 'play' | 'pause' | 'stop' | 'next' | 'previous' | 'volume' | 'mute' | 'repeat_off' | 'repeat_one' | 'repeat_all' | 'shuffle' | 'unshuffle' | 'switch' | 'seek' | 'seek_relative' - should be one of the values listed in `supported_commands` from the [`server/state`](#server--client-serverstate-controller-object) `controller` object. Commands not in `supported_commands` are ignored by the server
+  - `command`: 'play' | 'pause' | 'stop' | 'next' | 'previous' | 'volume' | 'mute' | 'repeat_off' | 'repeat_one' | 'repeat_all' | 'shuffle' | 'unshuffle' | 'switch' | 'seek' | 'seek_relative' - MUST be one of the values listed in `supported_commands` from the latest controller state the client received in [`server/state`](#server--client-serverstate-controller-object). The server MUST ignore commands absent from its current `supported_commands`
   - `volume?`: integer - volume range 0-100, only set if `command` is `volume`
   - `mute?`: boolean - true to mute, false to unmute, only set if `command` is `mute`
   - `position_ms?`: integer - absolute playback position in milliseconds, range 0 to [`seek_max_ms`](#server--client-serverstate-controller-object), only set if `command` is `seek`
@@ -1433,7 +1433,7 @@ Control the group that's playing and switch groups. Only valid from clients with
 
 #### Command behaviour
 
-- 'play' - resume playback from current position. If nothing is currently playing, the server must try to resume the group's last playing media. This history should persist across server and client reboots
+- 'play' - resume playback from current position. If nothing is currently playing, the server SHOULD resume the group's last playing media. The server SHOULD retain this history across server and client reboots
 - 'pause' - pause playback at current position
 - 'stop' - stop playback and reset position to beginning
 - 'next' - skip to next track, chapter, etc.
@@ -1449,7 +1449,7 @@ Control the group that's playing and switch groups. Only valid from clients with
 - 'seek' - seek to an absolute position. The client MUST include `position_ms`; the server MUST ignore the command if `position_ms` is outside the range 0 to `seek_max_ms`
 - 'seek_relative' - seek by an offset from the current position. The client MUST include `offset_ms`; the server applies it on a best-effort basis and MUST clamp the result to the seekable range
 
-**Setting group volume:** When setting group volume via the 'volume' command, the server applies the following algorithm to the players in the group that support the `volume` command, preserving relative volume levels while achieving the requested volume as closely as player boundaries allow. Players without volume support are excluded and receive no volume command:
+**Setting group volume:** When setting group volume via the 'volume' command, the server MUST apply the following algorithm to the players in the group that support the `volume` command, preserving relative volume levels while achieving the requested volume as closely as player boundaries allow. Players without volume support are excluded and receive no volume command:
 
 1. Calculate the delta: `delta = requested_volume - current_group_volume` (where current group volume is the average of their volumes)
 2. Apply the delta to each player's volume
@@ -1461,9 +1461,11 @@ Control the group that's playing and switch groups. Only valid from clients with
      - All delta has been successfully applied, or
      - All players are clamped at their volume boundaries
 
+After the loop, the server MUST round each final per-player volume to the nearest integer before sending commands.
+
 The loop only computes the final per-player volumes; once it completes, the server sends each player a single volume command — intermediate values are never sent.
 
-This ensures that when setting group volume to 100%, all players will reach 100% if possible, and the final group volume matches the requested volume as closely as player boundaries allow.
+This ensures that when setting group volume to 100%, all players will reach 100% if possible, and the final group volume matches the requested volume as closely as player boundaries and rounding allow.
 
 **Setting group mute:** When setting group mute via the 'mute' command, the server applies the mute state to each player in the group that supports the `mute` command. Group volume changes do not affect any player's `muted` state (see the [player role](#player-messages)).
 

--- a/roles/controller/v1.md
+++ b/roles/controller/v1.md
@@ -1,16 +1,16 @@
 ## Controller messages
 This section describes messages specific to clients with the `controller` role, which enables the client to control the group this client is part of, and switch between groups.
 
-Every client which lists the `controller` role in the `supported_roles` of the `client/hello` message needs to implement all messages in this section.
+Every client which lists the `controller` role in the `supported_roles` of the `client/hello` message MUST implement all messages in this section.
 
 ### Client → Server: `client/command` controller object
 
 The `controller` object in [`client/command`](../../messaging.md#client--server-clientcommand) has this structure:
 
-Control the group that's playing and switch groups. Only valid from clients with the `controller` role.
+Control the group that's playing and switch groups. Only valid from clients whose `controller` role is active.
 
 - `controller`: object
-  - `command`: 'play' | 'pause' | 'stop' | 'next' | 'previous' | 'volume' | 'mute' | 'repeat_off' | 'repeat_one' | 'repeat_all' | 'shuffle' | 'unshuffle' | 'switch' | 'seek' | 'seek_relative' - should be one of the values listed in `supported_commands` from the [`server/state`](#server--client-serverstate-controller-object) `controller` object. Commands not in `supported_commands` are ignored by the server
+  - `command`: 'play' | 'pause' | 'stop' | 'next' | 'previous' | 'volume' | 'mute' | 'repeat_off' | 'repeat_one' | 'repeat_all' | 'shuffle' | 'unshuffle' | 'switch' | 'seek' | 'seek_relative' - MUST be one of the values listed in `supported_commands` from the latest controller state the client received in [`server/state`](#server--client-serverstate-controller-object). The server MUST ignore commands absent from its current `supported_commands`
   - `volume?`: integer - volume range 0-100, only set if `command` is `volume`
   - `mute?`: boolean - true to mute, false to unmute, only set if `command` is `mute`
   - `position_ms?`: integer - absolute playback position in milliseconds, range 0 to [`seek_max_ms`](#server--client-serverstate-controller-object), only set if `command` is `seek`
@@ -18,7 +18,7 @@ Control the group that's playing and switch groups. Only valid from clients with
 
 #### Command behaviour
 
-- 'play' - resume playback from current position. If nothing is currently playing, the server must try to resume the group's last playing media. This history should persist across server and client reboots
+- 'play' - resume playback from current position. If nothing is currently playing, the server SHOULD resume the group's last playing media. The server SHOULD retain this history across server and client reboots
 - 'pause' - pause playback at current position
 - 'stop' - stop playback and reset position to beginning
 - 'next' - skip to next track, chapter, etc.
@@ -34,7 +34,7 @@ Control the group that's playing and switch groups. Only valid from clients with
 - 'seek' - seek to an absolute position. The client MUST include `position_ms`; the server MUST ignore the command if `position_ms` is outside the range 0 to `seek_max_ms`
 - 'seek_relative' - seek by an offset from the current position. The client MUST include `offset_ms`; the server applies it on a best-effort basis and MUST clamp the result to the seekable range
 
-**Setting group volume:** When setting group volume via the 'volume' command, the server applies the following algorithm to the players in the group that support the `volume` command, preserving relative volume levels while achieving the requested volume as closely as player boundaries allow. Players without volume support are excluded and receive no volume command:
+**Setting group volume:** When setting group volume via the 'volume' command, the server MUST apply the following algorithm to the players in the group that support the `volume` command, preserving relative volume levels while achieving the requested volume as closely as player boundaries allow. Players without volume support are excluded and receive no volume command:
 
 1. Calculate the delta: `delta = requested_volume - current_group_volume` (where current group volume is the average of their volumes)
 2. Apply the delta to each player's volume
@@ -46,9 +46,11 @@ Control the group that's playing and switch groups. Only valid from clients with
      - All delta has been successfully applied, or
      - All players are clamped at their volume boundaries
 
+After the loop, the server MUST round each final per-player volume to the nearest integer before sending commands.
+
 The loop only computes the final per-player volumes; once it completes, the server sends each player a single volume command — intermediate values are never sent.
 
-This ensures that when setting group volume to 100%, all players will reach 100% if possible, and the final group volume matches the requested volume as closely as player boundaries allow.
+This ensures that when setting group volume to 100%, all players will reach 100% if possible, and the final group volume matches the requested volume as closely as player boundaries and rounding allow.
 
 **Setting group mute:** When setting group mute via the 'mute' command, the server applies the mute state to each player in the group that supports the `mute` command. Group volume changes do not affect any player's `muted` state (see the [player role](../player/v1.md#player-messages)).
 


### PR DESCRIPTION
Normalize controller requirement wording and make the existing group-volume algorithm obligation explicit. Changes beyond keyword normalization:

- Require commands to be selected from the latest supported-command list received by the client, rather than merely recommending it. Clarify that the controller role must be active and that the server MUST ignore commands absent from its current list - support changes and commands can cross in flight.
- Replace "must try to resume" with SHOULD resume the group's last playing media, and explicitly assign history retention across server and client reboots to the server - resumption is not always possible.
- Require rounding each final per-player volume to the nearest integer after redistribution and before sending commands. Account for rounding in the stated accuracy of the resulting group volume - redistribution can produce fractions, but player volume commands require integers.

Addresses part of #100.