### PR TITLE
Clarify visualizer buffering and data handling requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1634,7 +1634,7 @@ This section describes messages specific to clients with the `visualizer` role, 
 
 Each visualizer binary message carries exactly one frame. The server emits messages in non-decreasing timestamp order so clients can process them in arrival order. Types the server cannot stream for the current source are silently omitted from the set echoed in [`stream/start`](#server--client-streamstart-visualizer-object). `beat` and `peak` are event-driven and not throttled by `rate_max`; all other types are periodic.
 
-Timestamps may decrease only after [`stream/clear`](#server--client-streamclear-visualizer) or when starting a new stream. Updating an existing stream with `stream/start` does not allow timestamps to decrease.
+Timestamps MAY decrease only after [`stream/clear`](#server--client-streamclear-visualizer) or when starting a new stream. Updating an existing stream with `stream/start` does not allow timestamps to decrease.
 
 **`beat` vs `peak`:** `beat` is a musical pulse derived from tempo/beat tracking, landing on the rhythmic grid with downbeats marking bar starts. Accurate beat detection often relies on offline analysis (e.g. neural beat trackers); servers without such analysis omit the type. `peak` is an energy onset detected live from the audio stream and fires on any transient (drum hits, cymbal crashes, attacks), independent of the rhythmic grid. A `beat` and a `peak` can fire on the same hit, or a `peak` can fire mid-bar with no `beat`.
 
@@ -1654,8 +1654,8 @@ The requested data types, frame-rate cap, and spectrum configuration are dynamic
 The `visualizer` object in [`client/state`](#client--server-clientstate) has this structure:
 
 - `visualizer`: object
-  - `types`: string[] - visualization data types requested by the client: 'beat', 'loudness', 'f_peak', 'peak', 'spectrum'. May be empty to request no visualization data
-  - `rate_max`: positive integer - maximum periodic visualization frames per second per type (applies independently to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo. Clients should set this to their display refresh rate
+  - `types`: string[] - visualization data types requested by the client: 'beat', 'loudness', 'f_peak', 'peak', 'spectrum'. MAY be empty to request no visualization data
+  - `rate_max`: positive integer - maximum periodic visualization frames per second per type (applies independently to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo. Clients SHOULD set this to their display refresh rate
   - `spectrum?`: object - spectrum configuration, required if `types` includes 'spectrum'
     - `n_disp_bins`: integer - number of display bins (i.e. bars on a graphical equalizer)
     - `scale`: 'mel' | 'log' | 'lin' - mapping from FFT frequencies to display bins. 'mel' uses the HTK mel formula (`m = 2595 * log10(1 + f/700)`), 'log' uses base-10 logarithm of frequency, 'lin' uses linear frequency spacing
@@ -1682,21 +1682,25 @@ The `visualizer` object in [`stream/start`](#server--client-streamstart) has thi
 
 ### Server → Client: `stream/clear` visualizer
 
-When [`stream/clear`](#server--client-streamclear) includes the visualizer role, clients should clear all buffered visualization data and continue with data received after this message.
+When [`stream/clear`](#server--client-streamclear) includes the visualizer role, clients MUST clear all buffered visualization data and continue with data received after this message.
 
 ### Server → Client: Visualization Data (Binary)
 
-Binary messages SHOULD be rejected if there is no active stream or the client is not [`available`](#client--server-clientstate). Each visualization `type` has its own binary message type. Every message carries exactly one frame of `[timestamp:8][data]`:
+Servers MUST NOT send visualization messages outside an active visualizer stream.
+
+During an active stream, unavailable clients SHOULD discard otherwise valid visualization data and MUST NOT close solely for its arrival.
+
+Each visualization `type` has its own binary message type. Every message carries exactly one frame of `[timestamp:8][data]`:
 
 - Byte 0: message type (uint8, one of the types listed below)
-- Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when this data should be displayed. Clients must translate this server timestamp to their local clock using the [time filter](#clock-synchronization)
+- Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when this data should be displayed. Clients MUST translate this server timestamp to their local clock using the [time filter](#clock-synchronization)
 - Remaining bytes: data, layout per type below; all `uint16` fields are big-endian
 
 Data whose timestamp is already in the past on arrival is dropped; stale visualization frames are never rendered.
 
 `loudness`, `spectrum` bins, and the `f_peak` amplitude use the full `uint16` range 0-65535, where 0 = silence and 65535 = full scale. Values are A-weighted and dB-scaled: -60 dB → 0, 0 dB → 65535, mapped linearly across that range.
 
-Message types `21`, `22`, and `23` are reserved for future visualizer types within the role's 16-23 allocation and must not be used by implementations.
+Message types `21`, `22`, and `23` are reserved for future visualizer types within the role's 16-23 allocation and MUST NOT be used by implementations.
 
 #### `loudness` — message type `16`
 
@@ -1706,13 +1710,13 @@ Overall A-weighted loudness in dB (see scaling above).
 
 #### `beat` — message type `17`
 
-- 1 byte: `uint8` flags. Bit 0 = downbeat (bar start). Bits 1-7 reserved, must be zero by the server, ignored by the client
+- 1 byte: `uint8` flags. Bit 0 = downbeat (bar start). Bits 1-7 reserved, MUST be set to zero by the server, ignored by the client
 
 Musical beat event. Bit 0 is only meaningful when [`stream/start`](#server--client-streamstart-visualizer-object) sets `tracks_downbeats: true`; otherwise it is always 0.
 
 #### `f_peak` — message type `18`
 
-- 2 bytes: `uint16` freq - dominant frequency in Hz (0 = no peak detected, amp must also be 0)
+- 2 bytes: `uint16` freq - dominant frequency in Hz (0 = no peak detected, amp MUST also be 0)
 - 2 bytes: `uint16` amp - amplitude (see scaling above)
 
 Tracks the dominant FFT bin, which is not always the fundamental: strong harmonics can dominate, so do not treat `f_peak` as the musical note being played.
@@ -1721,7 +1725,7 @@ Tracks the dominant FFT bin, which is not always the fundamental: strong harmoni
 
 - 2*n bytes: `uint16[n]` bins from low to high frequency. `n` = `n_disp_bins` in [`stream/start`](#server--client-streamstart-visualizer-object)
 
-Magnitude per display bin (see scaling above). Servers may impose an implementation-defined upper bound on `n_disp_bins` to keep per-frame size sensible.
+Magnitude per display bin (see scaling above). Servers MAY impose an implementation-defined upper bound on `n_disp_bins` to keep per-frame size sensible.
 
 #### `peak` — message type `20`
 

--- a/README.md
+++ b/README.md
@@ -1655,7 +1655,7 @@ The `visualizer` object in [`client/state`](#client--server-clientstate) has thi
 
 - `visualizer`: object
   - `types`: string[] - visualization data types requested by the client: 'beat', 'loudness', 'f_peak', 'peak', 'spectrum'. MAY be empty to request no visualization data
-  - `rate_max`: positive integer - maximum periodic visualization frames per second per type (applies independently to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo. Clients SHOULD set this to their display refresh rate
+  - `rate_max`: positive integer - maximum periodic visualization frames per second per type (applies independently to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo.
   - `spectrum?`: object - spectrum configuration, required if `types` includes 'spectrum'
     - `n_disp_bins`: integer - number of display bins (i.e. bars on a graphical equalizer)
     - `scale`: 'mel' | 'log' | 'lin' - mapping from FFT frequencies to display bins. 'mel' uses the HTK mel formula (`m = 2595 * log10(1 + f/700)`), 'log' uses base-10 logarithm of frequency, 'lin' uses linear frequency spacing

--- a/roles/visualizer/v1.md
+++ b/roles/visualizer/v1.md
@@ -3,7 +3,7 @@ This section describes messages specific to clients with the `visualizer` role, 
 
 Each visualizer binary message carries exactly one frame. The server emits messages in non-decreasing timestamp order so clients can process them in arrival order. Types the server cannot stream for the current source are silently omitted from the set echoed in [`stream/start`](#server--client-streamstart-visualizer-object). `beat` and `peak` are event-driven and not throttled by `rate_max`; all other types are periodic.
 
-Timestamps may decrease only after [`stream/clear`](#server--client-streamclear-visualizer) or when starting a new stream. Updating an existing stream with `stream/start` does not allow timestamps to decrease.
+Timestamps MAY decrease only after [`stream/clear`](#server--client-streamclear-visualizer) or when starting a new stream. Updating an existing stream with `stream/start` does not allow timestamps to decrease.
 
 **`beat` vs `peak`:** `beat` is a musical pulse derived from tempo/beat tracking, landing on the rhythmic grid with downbeats marking bar starts. Accurate beat detection often relies on offline analysis (e.g. neural beat trackers); servers without such analysis omit the type. `peak` is an energy onset detected live from the audio stream and fires on any transient (drum hits, cymbal crashes, attacks), independent of the rhythmic grid. A `beat` and a `peak` can fire on the same hit, or a `peak` can fire mid-bar with no `beat`.
 
@@ -23,8 +23,8 @@ The requested data types, frame-rate cap, and spectrum configuration are dynamic
 The `visualizer` object in [`client/state`](../../messaging.md#client--server-clientstate) has this structure:
 
 - `visualizer`: object
-  - `types`: string[] - visualization data types requested by the client: 'beat', 'loudness', 'f_peak', 'peak', 'spectrum'. May be empty to request no visualization data
-  - `rate_max`: positive integer - maximum periodic visualization frames per second per type (applies independently to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo. Clients should set this to their display refresh rate
+  - `types`: string[] - visualization data types requested by the client: 'beat', 'loudness', 'f_peak', 'peak', 'spectrum'. MAY be empty to request no visualization data
+  - `rate_max`: positive integer - maximum periodic visualization frames per second per type (applies independently to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo. Clients SHOULD set this to their display refresh rate
   - `spectrum?`: object - spectrum configuration, required if `types` includes 'spectrum'
     - `n_disp_bins`: integer - number of display bins (i.e. bars on a graphical equalizer)
     - `scale`: 'mel' | 'log' | 'lin' - mapping from FFT frequencies to display bins. 'mel' uses the HTK mel formula (`m = 2595 * log10(1 + f/700)`), 'log' uses base-10 logarithm of frequency, 'lin' uses linear frequency spacing
@@ -51,21 +51,25 @@ The `visualizer` object in [`stream/start`](../../messaging.md#server--client-st
 
 ### Server → Client: `stream/clear` visualizer
 
-When [`stream/clear`](../../messaging.md#server--client-streamclear) includes the visualizer role, clients should clear all buffered visualization data and continue with data received after this message.
+When [`stream/clear`](../../messaging.md#server--client-streamclear) includes the visualizer role, clients MUST clear all buffered visualization data and continue with data received after this message.
 
 ### Server → Client: Visualization Data (Binary)
 
-Binary messages SHOULD be rejected if there is no active stream or the client is not [`available`](../../messaging.md#client--server-clientstate). Each visualization `type` has its own binary message type. Every message carries exactly one frame of `[timestamp:8][data]`:
+Servers MUST NOT send visualization messages outside an active visualizer stream.
+
+During an active stream, unavailable clients SHOULD discard otherwise valid visualization data and MUST NOT close solely for its arrival.
+
+Each visualization `type` has its own binary message type. Every message carries exactly one frame of `[timestamp:8][data]`:
 
 - Byte 0: message type (uint8, one of the types listed below)
-- Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when this data should be displayed. Clients must translate this server timestamp to their local clock using the [time filter](../../messaging.md#clock-synchronization)
+- Bytes 1-8: timestamp (big-endian int64) - server clock time in microseconds when this data should be displayed. Clients MUST translate this server timestamp to their local clock using the [time filter](../../messaging.md#clock-synchronization)
 - Remaining bytes: data, layout per type below; all `uint16` fields are big-endian
 
 Data whose timestamp is already in the past on arrival is dropped; stale visualization frames are never rendered.
 
 `loudness`, `spectrum` bins, and the `f_peak` amplitude use the full `uint16` range 0-65535, where 0 = silence and 65535 = full scale. Values are A-weighted and dB-scaled: -60 dB → 0, 0 dB → 65535, mapped linearly across that range.
 
-Message types `21`, `22`, and `23` are reserved for future visualizer types within the role's 16-23 allocation and must not be used by implementations.
+Message types `21`, `22`, and `23` are reserved for future visualizer types within the role's 16-23 allocation and MUST NOT be used by implementations.
 
 #### `loudness` — message type `16`
 
@@ -75,13 +79,13 @@ Overall A-weighted loudness in dB (see scaling above).
 
 #### `beat` — message type `17`
 
-- 1 byte: `uint8` flags. Bit 0 = downbeat (bar start). Bits 1-7 reserved, must be zero by the server, ignored by the client
+- 1 byte: `uint8` flags. Bit 0 = downbeat (bar start). Bits 1-7 reserved, MUST be set to zero by the server, ignored by the client
 
 Musical beat event. Bit 0 is only meaningful when [`stream/start`](#server--client-streamstart-visualizer-object) sets `tracks_downbeats: true`; otherwise it is always 0.
 
 #### `f_peak` — message type `18`
 
-- 2 bytes: `uint16` freq - dominant frequency in Hz (0 = no peak detected, amp must also be 0)
+- 2 bytes: `uint16` freq - dominant frequency in Hz (0 = no peak detected, amp MUST also be 0)
 - 2 bytes: `uint16` amp - amplitude (see scaling above)
 
 Tracks the dominant FFT bin, which is not always the fundamental: strong harmonics can dominate, so do not treat `f_peak` as the musical note being played.
@@ -90,7 +94,7 @@ Tracks the dominant FFT bin, which is not always the fundamental: strong harmoni
 
 - 2*n bytes: `uint16[n]` bins from low to high frequency. `n` = `n_disp_bins` in [`stream/start`](#server--client-streamstart-visualizer-object)
 
-Magnitude per display bin (see scaling above). Servers may impose an implementation-defined upper bound on `n_disp_bins` to keep per-frame size sensible.
+Magnitude per display bin (see scaling above). Servers MAY impose an implementation-defined upper bound on `n_disp_bins` to keep per-frame size sensible.
 
 #### `peak` — message type `20`
 

--- a/roles/visualizer/v1.md
+++ b/roles/visualizer/v1.md
@@ -24,7 +24,7 @@ The `visualizer` object in [`client/state`](../../messaging.md#client--server-cl
 
 - `visualizer`: object
   - `types`: string[] - visualization data types requested by the client: 'beat', 'loudness', 'f_peak', 'peak', 'spectrum'. MAY be empty to request no visualization data
-  - `rate_max`: positive integer - maximum periodic visualization frames per second per type (applies independently to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo. Clients SHOULD set this to their display refresh rate
+  - `rate_max`: positive integer - maximum periodic visualization frames per second per type (applies independently to `loudness`, `f_peak`, `spectrum`). Beat events are not throttled and are bounded by tempo.
   - `spectrum?`: object - spectrum configuration, required if `types` includes 'spectrum'
     - `n_disp_bins`: integer - number of display bins (i.e. bars on a graphical equalizer)
     - `scale`: 'mel' | 'log' | 'lin' - mapping from FFT frequencies to display bins. 'mel' uses the HTK mel formula (`m = 2595 * log10(1 + f/700)`), 'log' uses base-10 logarithm of frequency, 'lin' uses linear frequency spacing


### PR DESCRIPTION
Normalize visualizer requirement wording and clarify stream handling. Changes beyond keyword normalization:

- Change `stream/clear` handling from a recommendation to a MUST: clients clear all buffered visualization data and continue with data received after the message - seeks must not display buffered frames from the old position.
- Replace ambiguous binary-message rejection guidance with a sender prohibition outside an active visualizer stream - "reject" did not specify whether to discard data or close the connection.
- During an active stream, unavailable clients SHOULD discard otherwise valid visualization data and MUST NOT close solely because it arrived - availability updates and visualization data can cross in flight.
- Remove the recommendation to set `rate_max` to the display refresh rate - the desired visualization update rate need not match the display refresh rate.

Addresses part of #100.